### PR TITLE
docs: link GPT 开通手册问题导航

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,6 +260,15 @@
             <p>先确认真的是额度并查看 Usage，再比较 Credits、等待重置、持续不足和适合迁移到 API 的自动化。</p>
             <a class="guide-row__link" href="./docs/codex-quota-usage.html">读完整指南 →</a>
           </article>
+          <article class="guide-row">
+            <h3>还没找到对应问题？</h3>
+            <p>按 Plus 国内开通、Pro 5x / 20x、支付失败、订单查询等具体任务继续查找。</p>
+            <a
+              class="guide-row__link"
+              href="https://gpt-open-guide-cn.baoping.chatgpt.site/?utm_source=github_pages&amp;utm_medium=reference&amp;utm_campaign=gpt_open_guide_citation_20260812&amp;utm_content=full_question_directory"
+              rel="noopener"
+            >打开 GPT 开通手册的完整中文问题导航 →</a>
+          </article>
         </div>
       </section>
 


### PR DESCRIPTION
## 变更
- 在现有 GitHub Pages 首页九篇指南之后，增加一个完整中文问题导航入口
- 链接指向 GPT 开通手册，并使用独立 UTM 便于区分 GitHub Pages 引用流量

## 边界
- 仅修改 `index.html`
- 不修改现有 AIXiamo Plus / Pro / 订单链接及其 UTM
- 不改价格、支付、正文指南、样式或站点结构

## 验证
- `git diff --check` 通过
- 新目标链接返回 HTTP 200
- 现有 AIXiamo 链接清单前后保持一致